### PR TITLE
cmake: cleanup .so. suffixes from TA .so files

### DIFF
--- a/cmake/OpenTEEHelpers.cmake
+++ b/cmake/OpenTEEHelpers.cmake
@@ -62,8 +62,6 @@ function(opentee_add_ta)
 
     # Remove version suffix from shared library (libfoo.so instead of libfoo.so.0.0.0)
     set_target_properties(${TA_NAME} PROPERTIES
-        VERSION ""
-        SOVERSION ""
         PREFIX "lib"
         LIBRARY_OUTPUT_DIRECTORY "${_ta_output_dir}"
     )


### PR DESCRIPTION
Before this change, lib/TAs contained, for every TA, a symlink with suffix .so which points to library file which has suffix .so. (with extra period). After this change there won't be symlinks, but only library files with suffix .so without the extra period.

Before:
```
lrwxrwxrwx 3 root root     17 Jan  1  1970 libCryptoTest.so -> libCryptoTest.so.
-r-xr-xr-x 2 root root  77696 Jan  1  1970 libCryptoTest.so.
lrwxrwxrwx 3 root root     21 Jan  1  1970 libexample_digest.so -> libexample_digest.so.
-r-xr-xr-x 2 root root  70112 Jan  1  1970 libexample_digest.so.
lrwxrwxrwx 3 root root     17 Jan  1  1970 libexample_ta.so -> libexample_ta.so.
-r-xr-xr-x 2 root root  69528 Jan  1  1970 libexample_ta.so.
lrwxrwxrwx 3 root root     16 Jan  1  1970 libpkcs11_ta.so -> libpkcs11_ta.so.
-r-xr-xr-x 2 root root  75528 Jan  1  1970 libpkcs11_ta.so.
lrwxrwxrwx 3 root root     21 Jan  1  1970 libsign_ecdsa_256.so -> libsign_ecdsa_256.so.
-r-xr-xr-x 2 root root  70384 Jan  1  1970 libsign_ecdsa_256.so.
lrwxrwxrwx 3 root root     18 Jan  1  1970 libStorageTest.so -> libStorageTest.so.
-r-xr-xr-x 2 root root  72568 Jan  1  1970 libStorageTest.so.
lrwxrwxrwx 3 root root     22 Jan  1  1970 libta2ta_conn_test.so -> libta2ta_conn_test.so.
-r-xr-xr-x 2 root root  70432 Jan  1  1970 libta2ta_conn_test.so.
lrwxrwxrwx 3 root root     16 Jan  1  1970 libta2taTest.so -> libta2taTest.so.
-r-xr-xr-x 2 root root  70080 Jan  1  1970 libta2taTest.so.
lrwxrwxrwx 3 root root     19 Jan  1  1970 libta_conn_test.so -> libta_conn_test.so.
-r-xr-xr-x 2 root root 147456 Jan  1  1970 libta_conn_test.so.
lrwxrwxrwx 3 root root     21 Jan  1  1970 libta_panic_crash.so -> libta_panic_crash.so.
-r-xr-xr-x 2 root root  70008 Jan  1  1970 libta_panic_crash.so.
lrwxrwxrwx 3 root root     18 Jan  1  1970 libta_services.so -> libta_services.so.
-r-xr-xr-x 2 root root  70376 Jan  1  1970 libta_services.so.
lrwxrwxrwx 3 root root     17 Jan  1  1970 libuser_study.so -> libuser_study.so.
-r-xr-xr-x 2 root root  70592 Jan  1  1970 libuser_study.so.
```

After:
```
-r-xr-xr-x 2 root root  77696 Jan  1  1970 libCryptoTest.so
-r-xr-xr-x 2 root root  70112 Jan  1  1970 libexample_digest.so
-r-xr-xr-x 2 root root  69528 Jan  1  1970 libexample_ta.so
-r-xr-xr-x 2 root root  75528 Jan  1  1970 libpkcs11_ta.so
-r-xr-xr-x 2 root root  70384 Jan  1  1970 libsign_ecdsa_256.so
-r-xr-xr-x 2 root root  72568 Jan  1  1970 libStorageTest.so
-r-xr-xr-x 2 root root  70432 Jan  1  1970 libta2ta_conn_test.so
-r-xr-xr-x 2 root root  70080 Jan  1  1970 libta2taTest.so
-r-xr-xr-x 2 root root 147456 Jan  1  1970 libta_conn_test.so
-r-xr-xr-x 2 root root  70008 Jan  1  1970 libta_panic_crash.so
-r-xr-xr-x 2 root root  70376 Jan  1  1970 libta_services.so
-r-xr-xr-x 2 root root  70592 Jan  1  1970 libuser_study.so
```

Disclaimer: I only tested to build with NixOS, didn't try out what happens on Debian-based distributions for example

Even after this change, some non-TA files are placed in the TAs directory, but I'll leave fixing that for another PR:
```
Jan 21 22:32:46 m3builder tee_launcher[393854]: /build/source/emulator/launcher/launcher_mainloop.c:lib_main_loop:153  Entering the launcher mainloop
Jan 21 22:32:46 m3builder tee_manager[393853]: /build/source/emulator/manager/ta_dir_watch.c:add_new_ta:203  libCryptoTest.so : properties section is not found
Jan 21 22:32:46 m3builder tee_manager[393853]: /build/source/emulator/manager/ta_dir_watch.c:add_new_ta:229  TA "libCryptoTest.so" rejected
Jan 21 22:32:46 m3builder tee_manager[393853]: /build/source/emulator/manager/ta_dir_watch.c:add_new_ta:203  libStorageTest.so : properties section is not found
Jan 21 22:32:46 m3builder tee_manager[393853]: /build/source/emulator/manager/ta_dir_watch.c:add_new_ta:229  TA "libStorageTest.so" rejected
Jan 21 22:32:46 m3builder tee_manager[393853]: /build/source/emulator/manager/ta_dir_watch.c:add_new_ta:203  libta2taTest.so : properties section is not found
Jan 21 22:32:46 m3builder tee_manager[393853]: /build/source/emulator/manager/ta_dir_watch.c:add_new_ta:229  TA "libta2taTest.so" rejected
Jan 21 22:32:46 m3builder tee_manager[393853]: /build/source/emulator/manager/mainloop.c:lib_main_loop:220  Entering the Manager mainloop
```