### PR TITLE
manager logic_thread: use-after-free on panicked TA close

### DIFF
--- a/emulator/manager/logic_thread.c
+++ b/emulator/manager/logic_thread.c
@@ -1531,6 +1531,7 @@ static void close_session(struct manager_msg *man_msg)
 	}
 
 	if (session->status == sess_panicked) {
+		list_unlink(&session->list);
 		free_sess(session);
 		return;
 	}


### PR DESCRIPTION
This becomes visible as a segmentation fault, if you update to the latest nixos-unstable, which presumerably has newer version of GCC with stricter default flags set.

When a TA crashes or panics, its sessions are marked sess_panicked and the TA-side session nodes are freed. When the CA subsequently calls TEEC_CloseSession, close_session() detected the panicked status and freed the CA-side session with free_sess(), but did not first unlink it from the CA's session list.

Later, when the CA called TEEC_FinalizeContext, ca_finalize_context() invoked free_proc() which iterated the CA's session list and attempted to list_unlink the already-freed session node. The freed memory contained a garbage prev pointer, causing a segfault in list_remove_between.

Add the missing list_unlink() call before free_sess() so the session is properly removed from the CA's linked list before its memory is freed.